### PR TITLE
feat: add tcp over dns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ const _DNS = or(
 )
 
 const IP = or(base('ip4'), base('ip6'))
-const TCP = and(IP, base('tcp'))
+const TCP = or(
+  and(IP, base('tcp')),
+  and(_DNS, base('tcp'))
+)
 const UDP = and(IP, base('udp'))
 const UTP = and(UDP, base('utp'))
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -32,12 +32,15 @@ describe('multiaddr validation', function () {
 
   const goodTCP = [
     '/ip4/0.0.7.6/tcp/1234',
-    '/ip6/::/tcp/0'
+    '/ip6/::/tcp/0',
+    '/dns4/protocol.ai/tcp/80',
+    '/dnsaddr/protocol.ai/tcp/80'
   ]
 
   const badTCP = [
     '/tcp/12345',
-    '/ip6/fc00::/udp/5523/tcp/9543'
+    '/ip6/fc00::/udp/5523/tcp/9543',
+    '/dns4/protocol.ai'
   ]
 
   const goodUDP = [
@@ -171,7 +174,7 @@ describe('multiaddr validation', function () {
 
   it('DNS validation', function () {
     assertMatches(mafmt.DNS, goodDNS)
-    assertMismatches(mafmt.DNS, badDNS, badIP, goodTCP)
+    assertMismatches(mafmt.DNS, badDNS, badIP)
   })
 
   it('IP validation', function () {
@@ -196,7 +199,7 @@ describe('multiaddr validation', function () {
 
   it('HTTP validation', function () {
     assertMatches(mafmt.HTTP, goodHTTP)
-    assertMismatches(mafmt.HTTP, goodIP, goodTCP, goodUDP)
+    assertMismatches(mafmt.HTTP, goodIP, goodUDP)
   })
 
   it('HTTPS validation', function () {


### PR DESCRIPTION
Adds support for TCP over DNS. 

Required by https://github.com/libp2p/js-libp2p-tcp/issues/95. 

I used the example code mentioned in the issue, https://github.com/libp2p/js-libp2p-switch/issues/277, to successfully connect to the jupiter node over dns via the following addresses:
- /dns4/jupiter.i.ipfs.io/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
- /dnsaddr/jupiter.i.ipfs.io/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx