### PR TITLE
Allow Buffer Input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ exports.IPFS = IPFS
 
 function makeMatchesFunction (partialMatch) {
   return function matches (a) {
-    if (typeof a === 'string') {
+    if (!multiaddr.isMultiaddr(a)) {
       try {
         a = multiaddr(a)
       } catch (err) { // catch error


### PR DESCRIPTION
> This PR follows @alanshaw's suggestion from https://github.com/ipfs/is-ipfs/pull/27#discussion_r259793041

README states that input can be a Buffer, but [this line](https://github.com/multiformats/js-mafmt/blob/v6.0.6/src/index.js#L148) fails due to missing `buffer.protoNames` :upside_down_face: 

This PR:
- [x] restores support for `Buffer` input
- [x] moves validation to js-multiaddr (so in future we can allow typed arrays there without changing this lib)
- [x]  adds missing tests for object and Buffer variants.


**Note:** build may be broken due to aegir/highlight.js – see https://github.com/ipfs/aegir/issues/336 