### PR TITLE
Update to latest multiaddr (p2p by default over ipfs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check -- -i wrtc -i electron-webrtc
         - npm run lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ stages:
   - cov
 
 node_js:
+  - '12'
   - '10'
 
 os:

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "coverage-publish": "aegir coverage publish"
   },
   "pre-push": [
-    "lint",
-    "test"
+    "lint"
   ],
   "repository": "github:multiformats/js-mafmt",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^4.2.0"
   },
   "dependencies": {
-    "multiaddr": "^6.1.0"
+    "multiaddr": "^7.0.0"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",

--- a/src/index.js
+++ b/src/index.js
@@ -45,15 +45,11 @@ const HTTPS = or(
 )
 
 const WebRTCStar = or(
-  and(WebSockets, base('p2p-webrtc-star'), base('ipfs')),
-  and(WebSocketsSecure, base('p2p-webrtc-star'), base('ipfs')),
   and(WebSockets, base('p2p-webrtc-star'), base('p2p')),
   and(WebSocketsSecure, base('p2p-webrtc-star'), base('p2p'))
 )
 
 const WebSocketStar = or(
-  and(WebSockets, base('p2p-websocket-star'), base('ipfs')),
-  and(WebSocketsSecure, base('p2p-websocket-star'), base('ipfs')),
   and(WebSockets, base('p2p-websocket-star'), base('p2p')),
   and(WebSocketsSecure, base('p2p-websocket-star'), base('p2p')),
   and(WebSockets, base('p2p-websocket-star')),
@@ -78,15 +74,13 @@ const Reliable = or(
 
 // Unlike ws-star, stardust can run over any transport thus removing the requirement for websockets (but don't even think about running a stardust server over webrtc-star ;) )
 const Stardust = or(
-  and(Reliable, base('p2p-stardust'), base('ipfs')),
+  and(Reliable, base('p2p-stardust'), base('p2p')),
   and(Reliable, base('p2p-stardust'))
 )
 
 const _P2P = or(
-  and(Reliable, base('ipfs')),
   and(Reliable, base('p2p')),
   WebRTCStar,
-  base('ipfs'),
   base('p2p')
 )
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -164,6 +164,8 @@ describe('multiaddr validation', function () {
     '/ip4/127.0.0.1/tcp/20008/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip4/1.2.3.4/tcp/3456/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ].concat(goodCircuit)


### PR DESCRIPTION
As multiaddr now defaults to using `/p2p` over `/ipfs` we no longer need the logic for both. `/ipfs` is still supported as demonstrated in the tests, so this won't cause any backwards comatability issues with `/ipfs` addresses.