### PR TITLE
fix: webrtc-star should not require the p2p codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 js-mafmt
 ========
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Coverage Status](https://coveralls.io/repos/github/whyrusleeping/js-mafmt/badge.svg?branch=master)](https://coveralls.io/github/whyrusleeping/js-mafmt?branch=master)
-[![Travis CI](https://travis-ci.org/whyrusleeping/js-mafmt.svg?branch=master)](https://travis-ci.org/whyrusleeping/js-mafmt)
-[![Circle CI](https://circleci.com/gh/whyrusleeping/js-mafmt.svg?style=svg)](https://circleci.com/gh/whyrusleeping/js-mafmt)
-[![Dependency Status](https://david-dm.org/whyrusleeping/js-mafmt.svg?style=flat-square)](https://david-dm.org/whyrusleeping/js-mafmt) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![Dependency Status](https://david-dm.org/multiformats/js-mafmt.svg?style=flat-square)](https://david-dm.org/multiformats/js-mafmt)
+[![](https://img.shields.io/travis/multiformats/js-mafmt.svg?style=flat-square)](https://travis-ci.com/multiformats/js-mafmt)
+[![codecov](https://img.shields.io/codecov/c/github/multiformats/js-mafmt.svg?style=flat-square)](https://codecov.io/gh/multiformats/js-mafmt)
 
 > Javascript implementation of multiaddr validation
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Where `<FORMAT>` may be:
 | `WebSocketsSecure` | a "wss" over `TCP` or "wss" over `DNS` format multiaddr | `/ip6/::/tcp/0/wss` <br> `/dnsaddr/ipfs.io/wss` |
 | `HTTP` | a "http" over `TCP` or `DNS` or "http" over `DNS` format multiaddr | `/ip4/127.0.0.1/tcp/90/http` <br> `/dnsaddr/ipfs.io/http` |
 | `HTTPS` | a "https" over `TCP` or `DNS` or "https" over `DNS` format multiaddr | `/ip4/127.0.0.1/tcp/90/https` <br> `/dnsaddr/ipfs.io/https` |
-| `WebRTCStar` | an "ipfs" over "p2p-webrtc-star" over `Websockets` or "ipfs" over "p2p-webrtc-star" over `WebSocketsSecure` format multiaddr | `/dnsaddr/ipfs.io/wss/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4` |
-| `WebSocketStar` | an "ipfs" over "p2p-websocket-star" over `Websockets` or "ipfs" over "p2p-websocket-star" over `WebSocketsSecure` or "p2p-websocket-star" over `Websockets` or "p2p-websocket-star" over `WebSocketsSecure` format multiaddr | `/ip4/1.2.3.4/tcp/3456/ws/p2p-websocket-star` <br> `/dnsaddr/localhost/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4` |
+| `WebRTCStar` | a "p2p" over "p2p-webrtc-star" over `Websockets` or "p2p" over "p2p-webrtc-star" over `WebSocketsSecure` format multiaddr | `/dnsaddr/ipfs.io/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4` |
+| `WebSocketStar` | a "p2p" over "p2p-websocket-star" over `Websockets` or "p2p" over "p2p-websocket-star" over `WebSocketsSecure` or "p2p-websocket-star" over `Websockets` or "p2p-websocket-star" over `WebSocketsSecure` format multiaddr | `/ip4/1.2.3.4/tcp/3456/ws/p2p-websocket-star` <br> `/dnsaddr/localhost/ws/p2p-websocket-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4` |
 | `WebRTCDirect` | a "p2p-webrtc-direct" over `HTTP` or "p2p-webrtc-direct" over `HTTPS` format multiaddr | `/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct` |
 | `Reliable` | a `WebSockets` or `WebSocketsSecure` or `HTTP` or `HTTPS` or `WebRTCStar` or `WebRTCDirect` or `TCP` or `UTP` format multiaddr | `/dnsaddr/ipfs.io/wss` |
-| `Circuit` |  | `/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj` |
+| `Circuit` |  | `/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj` |
 | `P2P` | "p2p", aka "ipfs", over `Reliable` or `WebRTCStar` or "p2p" format multiaddr | `/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4` <br> `/ip4/127.0.0.1/tcp/20008/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj` |
 
 Where `multiaddr` may be:

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,9 @@ const HTTPS = or(
 
 const WebRTCStar = or(
   and(WebSockets, base('p2p-webrtc-star'), base('p2p')),
-  and(WebSocketsSecure, base('p2p-webrtc-star'), base('p2p'))
+  and(WebSocketsSecure, base('p2p-webrtc-star'), base('p2p')),
+  and(WebSockets, base('p2p-webrtc-star')),
+  and(WebSocketsSecure, base('p2p-webrtc-star'))
 )
 
 const WebSocketStar = or(

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -98,7 +98,9 @@ describe('multiaddr validation', function () {
     '/dnsaddr/ipfs.io/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/dnsaddr/ipfs.io/wss/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip6/::/tcp/0/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5',
+    '/ip6/::/tcp/0/ws/p2p-webrtc-star',
     '/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
+    '/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star',
     '/dns/wrtc-star.discovery.libp2p.io/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/dns/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
   ]
@@ -284,7 +286,7 @@ describe('multiaddr validation', function () {
 
   it('WebRTCStar validation', function () {
     assertMatches(mafmt.WebRTCStar, goodWebRTCStar)
-    assertMismatches(mafmt.WebRTCStar, goodIP, goodUDP, badWS)
+    assertMismatches(mafmt.WebRTCStar, goodIP, goodUDP, badWSS)
   })
 
   it('WebRTCDirect validation', function () {


### PR DESCRIPTION
This adds support for webrtc-star to not have to include the `p2p` codec. Similar to websocket-star a valid listening address does not need to include the p2p codec, but an advertised address may include it, if it cannot be inferred by an accompanied peer id.