### PR TITLE
chore: add buffer to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/chai": "^4.2.8",
     "@types/mocha": "^7.0.1",
     "aegir": "^22.0.0",
+    "buffer": "^5.6.0",
     "chai": "^4.2.0"
   },
   "dependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,9 +2,11 @@
 
 'use strict'
 
+const { Buffer } = require('buffer')
 const expect = require('chai').expect
-const mafmt = require('./../src')
 const multiaddr = require('multiaddr')
+
+const mafmt = require('./../src')
 
 describe('multiaddr validation', function () {
   const goodDNS = [


### PR DESCRIPTION
This PR adds buffer as a dependency to avoid relying on bundlers automatic node globals injection.

Context: https://github.com/ipfs/js-ipfs/issues/2924