### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,10 @@
     "@types/chai": "^4.2.8",
     "@types/mocha": "^8.0.0",
     "aegir": "^25.0.0",
-    "buffer": "^5.6.0",
-    "chai": "^4.2.0"
+    "uint8arrays": "^1.1.0"
   },
   "dependencies": {
-    "multiaddr": "^7.3.0"
+    "multiaddr": "^8.0.0"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ import Multiaddr = require('multiaddr');
 export declare interface Mafmt {
   toString(): string;
   input?: (Mafmt | (() => Mafmt))[];
-  matches: (a: string | Buffer | Multiaddr) => boolean;
+  matches: (a: string | Uint8Array | Multiaddr) => boolean;
   partialMatch: (protos: string[]) => boolean;
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,9 +2,9 @@
 
 'use strict'
 
-const { Buffer } = require('buffer')
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const mafmt = require('./../src')
 
@@ -182,7 +182,7 @@ describe('multiaddr validation', function () {
           expect(p.matches(testcase), `assertMatches: ${testcase} (string)`).to.be.eql(true)
           const ma = multiaddr(testcase)
           expect(p.matches(ma), `assertMatches: ${testcase} (multiaddr object)`).to.be.eql(true)
-          expect(p.matches(ma.buffer), `assertMatches: ${testcase} (multiaddr.buffer)`).to.be.eql(true)
+          expect(p.matches(ma.bytes), `assertMatches: ${testcase} (multiaddr.bytes)`).to.be.eql(true)
         } catch (err) {
           err.stack = '[testcase=' + JSON.stringify(testcase) + ', shouldMatch=true] ' + err.stack
           throw err
@@ -200,15 +200,15 @@ describe('multiaddr validation', function () {
           let validMultiaddrObj
           try {
             // if testcase string happens to be a valid multiaddr,
-            // we expect 'p' test to also return false for Multiaddr object and Buffer versions
+            // we expect 'p' test to also return false for Multiaddr object and Uint8Array versions
             validMultiaddrObj = multiaddr(testcase)
           } catch (e) {
             // Ignoring testcase as the string is not a multiaddr
-            // (There is a separate 'Buffer is invalid' test later below)
+            // (There is a separate 'Uint8Array is invalid' test later below)
           }
           if (validMultiaddrObj) {
             expect(p.matches(validMultiaddrObj), `assertMismatches: ${testcase} (multiaddr object)`).to.be.eql(false)
-            expect(p.matches(validMultiaddrObj.buffer), `assertMismatches: ${testcase} (multiaddr.buffer)`).to.be.eql(false)
+            expect(p.matches(validMultiaddrObj.bytes), `assertMismatches: ${testcase} (multiaddr.bytes)`).to.be.eql(false)
           }
         } catch (err) {
           err.stack = '[testcase=' + JSON.stringify(testcase) + ', shouldMatch=false] ' + err.stack
@@ -222,8 +222,8 @@ describe('multiaddr validation', function () {
     expect(mafmt.HTTP.matches('/http-google-com')).to.be.eql(false)
   })
 
-  it('do not throw if multiaddr Buffer is invalid', function () {
-    expect(mafmt.HTTP.matches(Buffer.from('no spoon'))).to.be.eql(false)
+  it('do not throw if multiaddr Uint8Array is invalid', function () {
+    expect(mafmt.HTTP.matches(uint8ArrayFromString('no spoon'))).to.be.eql(false)
   })
 
   it('DNS validation', function () {


### PR DESCRIPTION
BREAKING CHANGES:

- Now uses a version of `multiaddr` than has a `.bytes` property instead of `.buffer`