### PR TITLE
fix: add webrtc direct with p2p as valid P2P multiaddr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,8 @@ const WebSocketStar = or(
 )
 
 const WebRTCDirect = or(
+  and(HTTP, base('p2p-webrtc-direct'), base('p2p')),
+  and(HTTPS, base('p2p-webrtc-direct'), base('p2p')),
   and(HTTP, base('p2p-webrtc-direct')),
   and(HTTPS, base('p2p-webrtc-direct'))
 )
@@ -85,6 +87,7 @@ const Stardust = or(
 const _P2P = or(
   and(Reliable, base('p2p')),
   WebRTCStar,
+  WebRTCDirect,
   base('p2p')
 )
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -162,6 +162,7 @@ describe('multiaddr validation', function () {
   const goodIPFS = [
     '/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/QmPj9ZZ6notLfV9khV1FtxH1Goe5sVaUyqgoXrTYQWp382',
     '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',


### PR DESCRIPTION
This PR adds a `webrtc-direct` with /p2p/{ID} as a valid multiaddr.

This fixes one issue with https://github.com/libp2p/js-libp2p-webrtc-direct/issues/94#issuecomment-756613029 where using `webrc-direct` addresses as bootstrap nodes were not being dialled as they were not valid