### PR TITLE
fix: add /tls/ws as alias for /wss

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export const WebSocketsSecure = or(
   and(TCP, base('wss')),
   and(DNS, base('wss')),
   and(TCP, base('tls'), base('ws')),
-  and(DNS, base('tls'), base('ws')),
+  and(DNS, base('tls'), base('ws'))
 )
 
 export const HTTP = or(

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,9 @@ export const WebSockets = or(
 
 export const WebSocketsSecure = or(
   and(TCP, base('wss')),
-  and(DNS, base('wss'))
+  and(DNS, base('wss')),
+  and(TCP, base('tls'), base('ws')),
+  and(DNS, base('tls'), base('ws')),
 )
 
 export const HTTP = or(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -100,7 +100,10 @@ describe('multiaddr validation', function () {
   const goodWSS = [
     '/dnsaddr/ipfs.io/wss',
     '/ip4/1.2.3.4/tcp/3456/wss',
-    '/ip6/::/tcp/0/wss'
+    '/ip6/::/tcp/0/wss',
+    '/dnsaddr/ipfs.io/tls/ws',
+    '/ip4/1.2.3.4/tcp/3456/tls/ws',
+    '/ip6/::/tcp/0/tls/ws'
   ]
 
   const goodWebRTCStar = [


### PR DESCRIPTION
This has been an alias for 2 years, but this code only ever checked /wss. https://github.com/multiformats/multiaddr/blob/master/protocols.csv