### PR TITLE
fix!: Rename WebRTCDirect to P2PWebRTCDirect and deprecate

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@multiformats/multiaddr": "^11.0.0"
+    "@multiformats/multiaddr": "^12.0.0"
   },
   "devDependencies": {
     "aegir": "^37.5.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export const HTTPS = or(
   and(DNS, base('https'))
 )
 
-const _WebRTC = and(UDP, base('webrtc'), base('certhash'))
+const _WebRTC = and(UDP, base('webrtc-direct'), base('certhash'))
 export const WebRTC = or(
   and(_WebRTC, base('p2p')),
   _WebRTC

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,13 +58,16 @@ export const HTTPS = or(
   and(DNS, base('https'))
 )
 
-const _WebRTC = and(UDP, base('webrtc-direct'), base('certhash'))
-export const WebRTC = or(
-  and(_WebRTC, base('p2p')),
-  _WebRTC
+const _WebRTCDirect = and(UDP, base('webrtc-direct'), base('certhash'))
+export const WebRTCDirect = or(
+  and(_WebRTCDirect, base('p2p')),
+  _WebRTCDirect
 )
 
-export const WebRTCStar = or(
+/**
+ * @deprecated
+ */
+export const P2PWebRTCStar = or(
   and(WebSockets, base('p2p-webrtc-star'), base('p2p')),
   and(WebSocketsSecure, base('p2p-webrtc-star'), base('p2p')),
   and(WebSockets, base('p2p-webrtc-star')),
@@ -78,7 +81,10 @@ export const WebSocketStar = or(
   and(WebSocketsSecure, base('p2p-websocket-star'))
 )
 
-export const WebRTCDirect = or(
+/**
+ * @deprecated
+ */
+export const P2PWebRTCDirect = or(
   and(HTTP, base('p2p-webrtc-direct'), base('p2p')),
   and(HTTPS, base('p2p-webrtc-direct'), base('p2p')),
   and(HTTP, base('p2p-webrtc-direct')),
@@ -90,13 +96,13 @@ export const Reliable = or(
   WebSocketsSecure,
   HTTP,
   HTTPS,
-  WebRTCStar,
-  WebRTCDirect,
+  P2PWebRTCStar,
+  P2PWebRTCDirect,
   TCP,
   UTP,
   QUIC,
   DNS,
-  WebRTC
+  WebRTCDirect
 )
 
 // Unlike ws-star, stardust can run over any transport thus removing the requirement for websockets (but don't even think about running a stardust server over webrtc-star ;) )
@@ -107,9 +113,9 @@ export const Stardust = or(
 
 const _P2P = or(
   and(Reliable, base('p2p')),
-  WebRTCStar,
+  P2PWebRTCStar,
+  P2PWebRTCDirect,
   WebRTCDirect,
-  WebRTC,
   base('p2p')
 )
 
@@ -138,6 +144,12 @@ export const P2P = or(
 )
 
 export const IPFS = P2P
+
+export const WebRTC = or(
+  and(Circuit, base('webrtc')),
+  and(Reliable, base('webrtc')),
+  base('webrtc')
+)
 
 /*
  * Validation funcs

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -106,7 +106,7 @@ describe('multiaddr validation', function () {
     '/ip6/::/tcp/0/tls/ws'
   ]
 
-  const goodWebRTCStar = [
+  const goodP2PWebRTCStar = [
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/dnsaddr/ipfs.io/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/dnsaddr/ipfs.io/wss/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
@@ -118,7 +118,7 @@ describe('multiaddr validation', function () {
     '/dns/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
   ]
 
-  const goodWebRTCDirect = [
+  const goodP2PWebRTCDirect = [
     '/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct',
     '/ip6/::/tcp/0/http/p2p-webrtc-direct'
   ]
@@ -190,15 +190,26 @@ describe('multiaddr validation', function () {
     '/dns6/nyc-2.bootstrap.libp2p.io/tcp/443/wss/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ].concat(goodCircuit)
 
-  const goodWebRTC = [
+  const goodWebRTCDirect = [
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ]
 
-  const badWebRTC = [
+  const badWebRTCDirect = [
     '/ip4/0.0.0.0/udp/4004/webrtc-direct',
     '/ip4/0.0.0.0/tcp/4004/webrtc-direct',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
+  ]
+
+  const goodWebRTC = [
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/webrtc',
+    '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/webrtc',
+    '/webrtc'
+  ]
+
+  const badWebRTC = [
+    '/ip4/0.0.0.0/udp/webrtc',
+    '/ip4/0.0.0.0/tcp/12345/udp/2222/wss/webrtc'
   ]
 
   function assertMatches (p: Mafmt, ...tests: string[][]) {
@@ -316,14 +327,14 @@ describe('multiaddr validation', function () {
     assertMismatches(mafmt.Stardust, goodIP, goodUDP, badWS)
   })
 
-  it('WebRTCStar validation', function () {
-    assertMatches(mafmt.WebRTCStar, goodWebRTCStar)
-    assertMismatches(mafmt.WebRTCStar, goodIP, goodUDP, badWSS)
+  it('P2PWebRTCStar validation', function () {
+    assertMatches(mafmt.P2PWebRTCStar, goodP2PWebRTCStar)
+    assertMismatches(mafmt.P2PWebRTCStar, goodIP, goodUDP, badWSS)
   })
 
-  it('WebRTCDirect validation', function () {
-    assertMatches(mafmt.WebRTCDirect, goodWebRTCDirect)
-    assertMismatches(mafmt.WebRTCDirect, goodIP, goodUDP, badWS)
+  it('P2PWebRTCDirect validation', function () {
+    assertMatches(mafmt.P2PWebRTCDirect, goodP2PWebRTCDirect)
+    assertMismatches(mafmt.P2PWebRTCDirect, goodIP, goodUDP, badWS)
   })
 
   it('Circuit validation', function () {
@@ -333,6 +344,11 @@ describe('multiaddr validation', function () {
 
   it('IPFS validation', function () {
     assertMatches(mafmt.IPFS, goodIPFS)
+  })
+
+  it('WebRTCDirect validation', function () {
+    assertMatches(mafmt.WebRTCDirect, goodWebRTCDirect)
+    assertMismatches(mafmt.WebRTCDirect, badWebRTCDirect)
   })
 
   it('WebRTC validation', function () {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -191,14 +191,14 @@ describe('multiaddr validation', function () {
   ].concat(goodCircuit)
 
   const goodWebRTC = [
-    '/ip4/0.0.0.0/udp/4004/webrtc/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
-    '/ip4/0.0.0.0/udp/4004/webrtc/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ]
 
   const badWebRTC = [
-    '/ip4/0.0.0.0/udp/4004/webrtc',
-    '/ip4/0.0.0.0/tcp/4004/webrtc',
-    '/ip4/0.0.0.0/udp/4004/webrtc/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct',
+    '/ip4/0.0.0.0/tcp/4004/webrtc-direct',
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ]
 
   function assertMatches (p: Mafmt, ...tests: string[][]) {


### PR DESCRIPTION
Rename webrtc protocol from webrtc to webrtc-direct based on https://github.com/multiformats/multiaddr/pull/152 .

BREAKING CHANGE: the existing WebRTCDirect multicodec name has been deprecated and renamed P2PWebRTCDirect. The new WebRTCDirect codec has been added but is not the same, please check your code before upgrading!  Integer codes are unchanged.