### PR TITLE
fix: match complete webRTC address

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,9 @@ export const P2P = or(
 export const IPFS = P2P
 
 export const WebRTC = or(
+  and(Circuit, base('webrtc'), base('p2p')),
   and(Circuit, base('webrtc')),
+  and(Reliable, base('webrtc'), base('p2p')),
   and(Reliable, base('webrtc')),
   base('webrtc')
 )

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -202,6 +202,7 @@ describe('multiaddr validation', function () {
   ]
 
   const goodWebRTC = [
+    '/ip4/127.0.0.1/tcp/59119/ws/p2p/12D3KooWAzabxK2xhwGQuTUYjbcFT9SZcNvPS1cvj7bPMe2Rh9qF/p2p-circuit/webrtc/p2p/12D3KooWA6L4J1yRwqLwdXPZBxz3UL4E8pEE6AEhFkqDH5LTQyfq',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/webrtc',
     '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/webrtc',
     '/webrtc'


### PR DESCRIPTION
According to the spec the address should terminate with the peer id in order to tunnel the SDP handshake through the underlying p2p-circuit address.