### PR TITLE
fix: remove engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
   "keywords": [
     "multiaddr"
   ],
-  "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.6.0"
-  },
   "type": "module",
   "types": "./dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
When the current node version does not meet the engines field requirement npm warns but yarn errors.

Nothing in this module requires node 18+ so remove the engines field.

Refs: https://github.com/ipfs/aegir/issues/1276
Fixes: #154